### PR TITLE
feat: add email sending service with nodemailer and Express route

### DIFF
--- a/src/BroadcastMailService/mailService.test.ts
+++ b/src/BroadcastMailService/mailService.test.ts
@@ -1,0 +1,57 @@
+// mailService.test.ts
+
+import nodemailer from 'nodemailer';
+import { sendEmail, MailOptions } from './mailService';
+
+// Mock nodemailer module
+jest.mock('nodemailer');
+
+const mockSendMail = jest.fn();
+
+// Setup mock implementation before tests
+beforeAll(() => {
+  // @ts-ignore - mock createTransport to return an object with sendMail method
+  nodemailer.createTransport.mockReturnValue({
+    sendMail: mockSendMail,
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('sendEmail function', () => {
+  const mailOptions: MailOptions = {
+    smtpUser: 'testuser@gmail.com',
+    smtpPass: 'testpassword',
+    from: 'testuser@gmail.com',
+    to: 'recipient@example.com',
+    subject: 'Hello',
+    message: 'Test message body',
+  };
+
+  it('should send email successfully', async () => {
+    mockSendMail.mockResolvedValueOnce(true);
+
+    const result = await sendEmail(mailOptions);
+
+    expect(mockSendMail).toHaveBeenCalledWith({
+      from: mailOptions.from,
+      to: mailOptions.to,
+      subject: mailOptions.subject,
+      text: mailOptions.message,
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it('should return error when sendMail throws', async () => {
+    const error = new Error('SMTP failure');
+    mockSendMail.mockRejectedValueOnce(error);
+
+    const result = await sendEmail(mailOptions);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('SMTP failure');
+  });
+});

--- a/src/BroadcastMailService/mailService.ts
+++ b/src/BroadcastMailService/mailService.ts
@@ -1,0 +1,34 @@
+import nodemailer from 'nodemailer';
+
+export interface MailOptions {
+  smtpUser: string;
+  smtpPass: string;
+  from: string;
+  to: string;
+  subject: string;
+  message: string;
+}
+
+export async function sendEmail({
+  smtpUser,
+  smtpPass,
+  from,
+  to,
+  subject,
+  message
+}: MailOptions): Promise<{ success: boolean; error?: string }> {
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: smtpUser,
+      pass: smtpPass
+    }
+  });
+
+  try {
+    await transporter.sendMail({ from, to, subject, text: message });
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import cors from 'cors';
+import sendEmailRouter from '../routes/sendEmailRoute';
+
+const app = express(); // ✅ Move this to the top
+const PORT = process.env.PORT || 5000;
+
+app.use(cors());
+app.use(express.json());
+
+app.use('/api', sendEmailRouter); // ✅ Now it's after 'app' is declared
+
+app.listen(PORT, () => {
+  console.log(`Server is running on http://localhost:${PORT}`);
+});

--- a/src/routes/sendEmailRoute.ts
+++ b/src/routes/sendEmailRoute.ts
@@ -1,0 +1,23 @@
+import express, { Request, Response } from 'express';
+import { sendEmail } from '../BroadcastMailService/mailService';
+
+const router = express.Router();
+
+router.post('/send-email', async (req: Request, res: Response): Promise<void> => {
+  const { smtpUser, smtpPass, from, to, subject, message } = req.body;
+
+  if (!smtpUser || !smtpPass || !from || !to || !subject || !message) {
+    res.status(400).json({ success: false, error: 'Missing required fields' });
+    return;
+  }
+
+  const result = await sendEmail({ smtpUser, smtpPass, from, to, subject, message });
+
+  if (result.success) {
+    res.json({ success: true });
+  } else {
+    res.status(500).json({ success: false, error: result.error });
+  }
+});
+
+export default router;


### PR DESCRIPTION
- implemented sendEmail function using nodemailer
- created Express route POST /api/send-email for sending emails
- added Jest unit tests mocking nodemailer for sendEmail
- fixed TypeScript types and routing issues