### PR TITLE
#365-Milton-1 Add start and start:prod Scripts to package.json for Development and Production Modes

### DIFF
--- a/electron/public/main.cjs
+++ b/electron/public/main.cjs
@@ -1,7 +1,7 @@
 const { app, BrowserWindow, Menu, dialog } = require('electron');
 const path = require('path');
 
-const isDev = !app.isPackaged;
+const isDev = process.env.VITE_DEV_SERVER === 'true';
 const menuTemplate = [
   ...(process.platform === 'darwin'
     ? [
@@ -80,8 +80,9 @@ function createWindow() {
   });
   if (isDev) {
     win.loadURL('http://localhost:5173');
-  } else {
-     win.loadFile(path.join(__dirname, '../dist/index.html'));
+  } else 
+  {
+     win.loadFile(path.join(__dirname, '../../dist/index.html'));
   }
 
   const menu = Menu.buildFromTemplate(menuTemplate);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently \"vite\" \"npm run electron:dev\"",
+    "dev": "VITE_DEV_SERVER=true concurrently \"vite\" \"npm run electron:dev\"",
     "electron:dev": "wait-on http://localhost:5173 && electron electron/public/main.cjs",
     "build": "vite build",
     "start": "npm run dev",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 
 export default defineConfig({
+    base: './',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
### Summary
Added "start" and "start:prod" scripts to `package.json` to improve development and production build workflows.

### Changes Made
- Added `"start": "npm run dev"` for development convenience.
- Moved production start command to `"start:prod"`.
- Verified that both `npm start` and `npm run start:prod` work as intended.

### How to Test
1. Run `npm start` — should launch the development environment.
2. Run  `npm run start:prod` — should launch production Electron app.

### Related Issues
Closes #365  
Closes #366  
Closes #367  
Closes #368