### PR TITLE
Save Uploaded Student Data Implementation

### DIFF
--- a/src/Services/SaveUploadedEvaluationData.test.ts
+++ b/src/Services/SaveUploadedEvaluationData.test.ts
@@ -1,0 +1,79 @@
+import { createSaveUploadedEvaluationData, CsvHandler } from '../Services/SaveUploadedEvaluationData'
+import { EvaluationService, Evaluation } from '../Services/SaveUploadedEvaluationData'
+import { LocalStorage } from '../localStorageService';
+
+describe('saveUploadedEvaluationData Integration Test', () => {
+  const STORAGE_KEY = 'evaluationFilename';
+  const fileName = 'test-evaluation.csv';
+
+  const sampleData: Evaluation[] = [
+    {
+      course: 'MATH101',
+      title: 'Final Exam',
+      type: 'Final Exam',
+      weight: 40,
+      dueDate: new Date('2025-12-10'),
+      instructor: 'Dr. Allen',
+      campus: 'Main',
+    }
+  ];
+
+  let capturedLogs: any[] = [];
+  const originalConsoleLog = console.log;
+
+  beforeEach(() => {
+    localStorage.clear();
+    capturedLogs = [];
+    console.log = (...args: any[]) => capturedLogs.push(args.join(' '));
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+  });
+
+  it('handles saving with empty evaluation list', () => {
+    const storage = new LocalStorage();
+    const service = new EvaluationService(storage);
+    const save = createSaveUploadedEvaluationData(service, storage, CsvHandler);
+
+    save([], fileName);
+
+    const loaded = service.loadEvaluations();
+    expect(loaded).toEqual([]);
+
+    const storedFile = localStorage.getItem(STORAGE_KEY);
+    expect(storedFile).toBe(JSON.stringify(fileName));
+  });
+
+  it('supports filenames with special characters', () => {
+    const specialName = 'Eval_Ü@#2025.csv';
+    const storage = new LocalStorage();
+    const service = new EvaluationService(storage);
+    const save = createSaveUploadedEvaluationData(service, storage, CsvHandler);
+
+    save(sampleData, specialName);
+
+    const storedFile = localStorage.getItem(STORAGE_KEY);
+    expect(storedFile).toBe(JSON.stringify(specialName));
+  });
+
+  it('should not throw when dueDate is invalid or missing', () => {
+    const malformedData: any[] = [{
+      course: 'SCI100',
+      title: 'Quiz',
+      type: 'Quiz',
+      weight: '25',
+      dueDate: '',
+      instructor: '',
+      campus: ''
+    }];
+
+    const storage = new LocalStorage();
+    const service = new EvaluationService(storage);
+    const save = createSaveUploadedEvaluationData(service, storage, CsvHandler);
+
+    expect(() => save(malformedData, fileName)).not.toThrow();
+  });
+});
+
+export { EvaluationService };

--- a/src/Services/SaveUploadedEvaluationData.ts
+++ b/src/Services/SaveUploadedEvaluationData.ts
@@ -1,0 +1,28 @@
+import { Evaluation, EvaluationService } from '../Evaluation/EvaluationService';
+import { StorageService } from '../localStorageService/StorageService';
+
+const EVALUATION_FILENAME_STORAGE_KEY = 'evaluationFilename';
+
+export class CsvHandler {
+  static saveDataToFile(fileName: string, data: Evaluation[]): void {
+    console.log(`Saving CSV Data: ${fileName}`, data);
+  }
+}
+
+export function createSaveUploadedEvaluationData(
+  evaluationService: EvaluationService,
+  storageService: StorageService,
+  csvHandler: typeof CsvHandler
+) {
+  return (data: Evaluation[], fileName: string): void => {
+    try {
+      evaluationService.saveEvaluations(data); // Save evaluations to service
+      storageService.save(EVALUATION_FILENAME_STORAGE_KEY, fileName); // Store filename
+      csvHandler.saveDataToFile(fileName, data); // Handle CSV persistence
+    } catch (error) {
+      console.error('Failed to save uploaded evaluation data:', error);
+    }
+  };
+}
+
+export { EvaluationService, Evaluation };

--- a/src/Services/SaveUploadedStudentData.test.ts
+++ b/src/Services/SaveUploadedStudentData.test.ts
@@ -1,0 +1,83 @@
+import { Student } from '../ParseCsvService'
+import { StorageService } from '../localStorageService'
+import { createSaveUploadedStudentData } from './SaveUploadedStudentData';
+
+describe('saveUploadedStudentData', () => {
+  const STUDENT_FILENAME_STORAGE_KEY = 'studentFilename';
+  const STUDENT_DATA_STORAGE_KEY = 'studentData';
+
+  const testFileName = 'students-upload.csv';
+  const testStudents: Student[] = [
+    {
+      studentId: '123',
+      name: 'Alice',
+      email: 'alice@example.com',
+      section: 'A1',
+      group: 'G1',
+      role: 'Developer',
+      imageUrl: '',
+      notes: '',
+      loopStatus: 'Active',
+      githubStatus: 'Active',
+    },
+  ];
+  const storage: Record<string, any> = {};
+  let savedOutput: { fileName: string; data: Student[] } | null = null;
+
+  class InMemoryStorageService implements StorageService {
+    save<T>(key: string, value: T): void {
+      storage[key] = JSON.stringify(value);
+    }
+    load<T>(key: string): T | null {
+      const raw = storage[key];
+      return raw ? JSON.parse(raw) : null;
+    }
+  }
+
+  class TestCsvHandler {
+    static saveDataToFile(fileName: string, data: Student[]): void {
+      savedOutput = { fileName, data };
+    }
+  }
+
+  let saveFn: ReturnType<typeof createSaveUploadedStudentData>;
+  let inMemoryStorage: InMemoryStorageService;
+
+  beforeEach(() => {
+    Object.keys(storage).forEach((key) => delete storage[key]);
+    savedOutput = null;
+    inMemoryStorage = new InMemoryStorageService();
+    saveFn = createSaveUploadedStudentData(inMemoryStorage, TestCsvHandler);
+  });
+
+  it('saves student data to in-memory storage', () => {
+    saveFn(testStudents, testFileName);
+    const result = inMemoryStorage.load<Student[]>(STUDENT_DATA_STORAGE_KEY);
+    expect(result).toEqual(testStudents);
+  });
+
+  it('saves file name to in-memory storage', () => {
+    saveFn(testStudents, testFileName);
+    const savedName = inMemoryStorage.load<string>(STUDENT_FILENAME_STORAGE_KEY);
+    expect(savedName).toBe(testFileName);
+  });
+
+  it('writes data to CsvHandler', () => {
+    saveFn(testStudents, testFileName);
+    expect(savedOutput).toEqual({ fileName: testFileName, data: testStudents });
+  });
+
+  it('handles empty data array', () => {
+    const empty: Student[] = [];
+    saveFn(empty, testFileName);
+    const saved = inMemoryStorage.load<Student[]>(STUDENT_DATA_STORAGE_KEY);
+    expect(saved).toEqual([]);
+  });
+
+  it('stores special characters in filename', () => {
+    const specialName = '@#$.csv';
+    saveFn(testStudents, specialName);
+    const saved = inMemoryStorage.load<string>(STUDENT_FILENAME_STORAGE_KEY);
+    expect(saved).toBe(specialName);
+  });
+});

--- a/src/Services/SaveUploadedStudentData.ts
+++ b/src/Services/SaveUploadedStudentData.ts
@@ -1,0 +1,25 @@
+import { Student } from '../ParseCsvService/ParseCsv'
+import { LocalStorage } from '../localStorageService/LocalStorage'
+
+const STUDENT_FILENAME_STORAGE_KEY = 'studentFilename';
+const STUDENT_DATA_STORAGE_KEY = 'studentData';
+
+export class StudentCsvHandler {
+  static saveDataToFile(fileName: string, data: Student[]): void {
+    console.log(`Saving student data to CSV file ${fileName}`, data);
+  }
+}
+export function createSaveUploadedStudentData(
+  storageService = new LocalStorage(),
+  csvHandler = StudentCsvHandler
+) {
+  return (data: Student[], fileName: string): void => {
+    try {
+      storageService.save(STUDENT_DATA_STORAGE_KEY, data);
+      storageService.save(STUDENT_FILENAME_STORAGE_KEY, fileName);
+      csvHandler.saveDataToFile(fileName, data);
+    } catch (error) {
+      console.error('Failed to save uploaded student data:', error);
+    }
+  };
+}


### PR DESCRIPTION
This PR implements functionality to handle the saving of uploaded student data using:

- LocalStorage for managing student data and filenames in localStorage

-  StudentCsvHandler for logging saved CSV data (placeholder for download/export logic)

- createSaveUploadedStudentData to coordinate saving both the data and the uploaded filename

This work is linked to Issue #543.

What’s Included
LocalStorage usage for:

- Saving parsed student data under the key 'studentData'
 

- Storing uploaded CSV filename under the key 'studentFilename'

StudentCsvHandler.saveDataToFile():

- Logs CSV file name and corresponding student data to console

- Structured for future replacement with real CSV download/export logic

createSaveUploadedStudentData():

Main function that handles:

- Persisting student data

- Storing uploaded filename

- Delegating CSV logging to handler