### PR TITLE
Issue 402 create heatmap UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,16 @@
-import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import ModuleNotFound from './Components/ModuleNotFound'; // adjust path if needed
+import React from "react";
+import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
+import ModuleNotFound from "./Components/ModuleNotFound"; // adjust path if needed
+import Heatmap from "./Evaluation/Heatmap/Heatmap";
+import { LocalStorage } from "./localStorageService";
+import {
+  Evaluation,
+  EvaluationService,
+} from "./Evaluation/EvaluationService/EvaluationService";
+
+const evaluations: Evaluation[] = new EvaluationService(
+  new LocalStorage()
+).loadEvaluations();
 
 function App() {
   return (
@@ -11,7 +21,11 @@ function App() {
           element={
             <div className="text-center">
               <header className="bg-[#282c34] min-h-screen flex flex-col items-center justify-center text-white text-[calc(10px+2vmin)]">
-                <img src="/src/assets/logo.png" className="h-[40vmin] pointer-events-none" alt="logo" />
+                <img
+                  src="/src/assets/logo.png"
+                  className="h-[40vmin] pointer-events-none"
+                  alt="logo"
+                />
                 <div>
                   <h1 className="text-4xl font-bold text-blue-600">
                     SQATE Desktop Tool
@@ -20,11 +34,23 @@ function App() {
                 <p className="mt-4 text-lg text-gray-300">
                   Welcome! This is the desktop shell for SQATE tooling modules.
                 </p>
+                <p>
+                  <Link
+                    to="/heatmap"
+                    className="mt-6 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+                  >
+                    Go to Heatmap
+                  </Link>
+                </p>
               </header>
             </div>
           }
         />
         <Route path="*" element={<ModuleNotFound />} />
+        <Route
+          path="/heatmap"
+          element={<Heatmap evaluations={evaluations} />}
+        />
       </Routes>
     </Router>
   );

--- a/src/Evaluation/Heatmap/Heatmap.test.tsx
+++ b/src/Evaluation/Heatmap/Heatmap.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Heatmap from './Heatmap';
+import { Evaluation } from '../EvaluationService';
+
+describe('Heatmap Component', () => {
+  const mockEvaluations: Evaluation[] = [
+    {
+      course: 'Math',
+      title: 'Midterm',
+      type: 'Mid Exam',
+      weight: 30,
+      dueDate: new Date('2025-07-03'),
+      instructor: 'X',
+      campus: 'Main',
+    },
+    {
+      course: 'History',
+      title: 'Essay',
+      type: 'Assignment',
+      weight: 10,
+      dueDate: new Date('2025-07-10'),
+      instructor: 'Y',
+      campus: 'North',
+    },
+    {
+      course: 'Physics',
+      title: 'Quiz',
+      type: 'Quiz',
+      weight: 5,
+      dueDate: new Date('2025-07-15'),
+      instructor: 'Z',
+      campus: 'Main',
+    },
+  ];
+
+  it('renders year dropdown and month view by default', () => {
+    render(<Heatmap evaluations={mockEvaluations} />);
+
+    expect(screen.getByLabelText(/Year:/)).toBeInTheDocument();
+    expect(screen.getByText(/Switch to Week View/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/evaluations/).length).toBeGreaterThan(0);
+  });
+
+  it('switches to week view and shows month selector', () => {
+    render(<Heatmap evaluations={mockEvaluations} />);
+
+    const toggleButton = screen.getByRole('button', { name: /Switch to Week View/i });
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByLabelText(/Month:/)).toBeInTheDocument();
+    expect(screen.getByText(/Switch to Month View/i)).toBeInTheDocument();
+  });
+
+  it('returns to month view when toggled back', () => {
+    render(<Heatmap evaluations={mockEvaluations} />);
+
+    const toggleButton = screen.getByRole('button', { name: /Switch to Week View/i });
+    fireEvent.click(toggleButton);
+
+    fireEvent.click(screen.getByRole('button', { name: /Switch to Month View/i }));
+
+    expect(screen.queryByLabelText(/Month:/)).not.toBeInTheDocument();
+  });
+});

--- a/src/Evaluation/Heatmap/Heatmap.tsx
+++ b/src/Evaluation/Heatmap/Heatmap.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import MonthView from './MonthView';
+import WeekView from './WeekView';
+import { Evaluation } from '../EvaluationService';
+
+type HeatmapProps = {
+  evaluations: Evaluation[];
+};
+
+const Heatmap: React.FC<HeatmapProps> = ({ evaluations }) => {
+  const currentDate = new Date();
+  const [viewMode, setViewMode] = useState<'month' | 'week'>('month');
+  const [year, setYear] = useState(currentDate.getFullYear());
+  const [month, setMonth] = useState(currentDate.getMonth());
+
+  const yearsToChoose = [year - 1, year, year + 1];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-4">
+        <label>
+          <span className="mr-2">Year:</span>
+          <select
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+            className="border rounded px-2 py-1"
+          >
+            {yearsToChoose.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {viewMode === 'week' && (
+          <label>
+            <span className="mr-2">Month:</span>
+            <select
+              value={month}
+              onChange={(e) => setMonth(Number(e.target.value))}
+              className="border rounded px-2 py-1"
+            >
+              {Array.from({ length: 12 }, (_, i) => (
+                <option key={i} value={i}>
+                  {new Date(0, i).toLocaleString('default', { month: 'long' })}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <button
+          onClick={() => setViewMode(viewMode === 'month' ? 'week' : 'month')}
+          className="bg-blue-600 text-white px-4 py-1 rounded"
+        >
+          Switch to {viewMode === 'month' ? 'Week View' : 'Month View'}
+        </button>
+      </div>
+
+      <div>
+        {viewMode === 'month' ? (
+          <MonthView year={year} evaluations={evaluations} />
+        ) : (
+          <WeekView year={year} month={month} evaluations={evaluations} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Heatmap;


### PR DESCRIPTION
##  Heatmap Component

This PR adds the Heatmap component, which provides a unified interface for viewing evaluation counts in either *Month View* or *Week View*.

---

###  What It Does

- Renders a heatmap of evaluations grouped by:
  - *Month*: aggregated per month
  - *Week*: full calendar weeks (Monday–Sunday) based on selected month
- Allows toggling between month/week views
- Provides dropdowns to select year and month (month dropdown is shown only in Week View)

---

###  Props

| Prop         | Type           | Description                              |
|--------------|----------------|------------------------------------------|
| evaluations | Evaluation[] | A list of evaluations with dueDate values |

---

###  Usage Example

tsx
import Heatmap from './Heatmap';

<Heatmap evaluations={sampleEvaluations} />


The evaluations prop should contain items with dueDate fields. Internally, Heatmap passes the appropriate filtered props to either MonthView or WeekView.

----------

###  Related Components

- MonthView: displays evaluation counts by month
    
- WeekView: displays counts for all weeks covering a selected month

<img width="1264" height="952" alt="Screenshot 2025-07-16 183002" src="https://github.com/user-attachments/assets/f2a9db7b-6cab-41c6-ab55-64d1ca9de792" />
<img width="1264" height="952" alt="Screenshot 2025-07-16 183021" src="https://github.com/user-attachments/assets/3b5f0f1d-9114-42cd-a239-90dc3244a98a" />

