### PR TITLE
Issue 400 create weekview for heatmap

### DIFF
--- a/src/Evaluation/Heatmap/Heatmap.tsx
+++ b/src/Evaluation/Heatmap/Heatmap.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Button from "../../Components/Button/Button";
+import WeekView from "./WeekView";
 
 type HeatmapProps = {};
 
@@ -52,6 +53,9 @@ const Heatmap: React.FC<HeatmapProps> = () => {
             viewMode === "month" ? "Week View" : "Month View"
           }`}
         />
+      </div>
+      <div>
+        {viewMode === 'week' ? (<WeekView year={year} month={month} />): null}
       </div>
     </div>
   );

--- a/src/Evaluation/Heatmap/Heatmap.tsx
+++ b/src/Evaluation/Heatmap/Heatmap.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import Button from "../../Components/Button/Button";
 import WeekView from "./WeekView";
+import { EvaluationService } from "../EvaluationService";
+import { LocalStorage } from "../../localStorageService";
 
 type HeatmapProps = {};
 
@@ -10,6 +12,7 @@ const Heatmap: React.FC<HeatmapProps> = () => {
   const [year, setYear] = useState(currentDate.getFullYear());
   const [month, setMonth] = useState(currentDate.getMonth());
 
+  const evaluations = new EvaluationService(new LocalStorage()).loadEvaluations();
   const yearsToChoose = [year - 1, year, year + 1];
 
   return (
@@ -55,7 +58,7 @@ const Heatmap: React.FC<HeatmapProps> = () => {
         />
       </div>
       <div>
-        {viewMode === 'week' ? (<WeekView year={year} month={month} />): null}
+        {viewMode === 'week' ? (<WeekView year={year} month={month} evaluations={evaluations}/>): null}
       </div>
     </div>
   );

--- a/src/Evaluation/Heatmap/WeekView.test.tsx
+++ b/src/Evaluation/Heatmap/WeekView.test.tsx
@@ -1,11 +1,49 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import WeekView from './WeekView';
+import { Evaluation } from '../EvaluationService';
 
 describe('WeekView', () => {
-  it('renders correct number of weekly blocks for July 2025', () => {
-    render(<WeekView year={2025} month={6} />);
-    const weekLabels = screen.getAllByText(/evaluations$/);
-    expect(weekLabels.length).toBeGreaterThanOrEqual(4);
+  const year = 2025;
+  const month = 6;
+
+  const createEval = (year: number, month: number, day: number): Evaluation => ({
+    course: 'Test Course',
+    title: 'Test Title',
+    type: 'Quiz',
+    weight: 10,
+    dueDate: new Date(year, month, day, 0, 0, 0),
+    instructor: 'X',
+    campus: 'Main',
+  });
+
+  const mockEvaluations: Evaluation[] = [
+    createEval(2025, 5 ,30),
+    createEval(2025, 6 ,1),
+    createEval(2025, 6 ,3),
+    createEval(2025, 6 ,10),
+    createEval(2025, 6 ,15),
+    createEval(2025, 6 ,24),
+    createEval(2025, 6 ,31),
+    createEval(2025, 7 ,1),
+  ];
+
+  it('renders the correct number of week blocks for July 2025', () => {
+    render(<WeekView year={year} month={month} evaluations={[]} />);
+
+    const weekLabels = screen.getAllByText(/ - /);
+    expect(weekLabels.length).toBe(5);
+  });
+
+  it('displays correct evaluation counts in each week', () => {
+    render(<WeekView year={year} month={month} evaluations={mockEvaluations} />);
+    const countElements = screen.getAllByText(/evaluations$/);
+ 
+    const counts = countElements.map(el => el.textContent?.trim());
+    expect(counts).toContain('3 evaluations');
+    expect(counts).toContain('1 evaluations');
+    expect(counts).toContain('1 evaluations');
+    expect(counts).toContain('1 evaluations');
+    expect(counts).toContain('2 evaluations');
   });
 });

--- a/src/Evaluation/Heatmap/WeekView.test.tsx
+++ b/src/Evaluation/Heatmap/WeekView.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import WeekView from './WeekView';
+
+describe('WeekView', () => {
+  it('renders correct number of weekly blocks for July 2025', () => {
+    render(<WeekView year={2025} month={6} />);
+    const weekLabels = screen.getAllByText(/evaluations$/);
+    expect(weekLabels.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/src/Evaluation/Heatmap/WeekView.tsx
+++ b/src/Evaluation/Heatmap/WeekView.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from 'react';
+
+type WeekViewProps = {
+  year: number;
+  month: number;
+};
+
+function getMonthWeekRange(year: number, month: number): { start: Date; end: Date } {
+  const firstDayOfMonth = new Date(year, month, 1);
+  const lastDayOfMonth = new Date(year, month + 1, 0);
+
+  const start = new Date(firstDayOfMonth);
+  const dayOfWeekStart = (start.getDay() + 6) % 7;
+  start.setDate(start.getDate() - dayOfWeekStart);
+
+  const end = new Date(lastDayOfMonth);
+  const dayOfWeekEnd = (end.getDay() + 6) % 7;
+  end.setDate(end.getDate() + (6 - dayOfWeekEnd));
+
+  return { start, end };
+}
+
+const WeekView: React.FC<WeekViewProps> = ({year, month}) => {
+  const weeklyData = useMemo(() => {
+    const { start, end } = getMonthWeekRange(year, month);
+    const weeks: { weekLabel: string; count: number }[] = [];
+
+    let cursor = new Date(start);
+    while (cursor <= end) {
+      const weekStart = new Date(cursor);
+      const weekEnd = new Date(cursor);
+      weekEnd.setDate(weekStart.getDate() + 6);
+
+      const label = `${weekStart.toLocaleDateString()} - ${weekEnd.toLocaleDateString()}`;
+
+      weeks.push({
+        weekLabel: label,
+        count: 0,
+      });
+
+      cursor.setDate(cursor.getDate() + 7);
+    }
+
+    return weeks;
+  }, [year, month]);
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+      {weeklyData.map(({ weekLabel, count }) => (
+        <div
+          key={weekLabel}
+          className={`rounded p-4 text-center shadow-sm ${
+            count ? 'text-white' : 'text-gray-500'
+          }`}
+        >
+          <div className="font-semibold">{weekLabel}</div>
+          <div className="text-sm mt-1">{count} evaluations</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default WeekView;

--- a/src/Evaluation/Heatmap/WeekView.tsx
+++ b/src/Evaluation/Heatmap/WeekView.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo } from 'react';
+import { Evaluation } from '../EvaluationService';
 
 type WeekViewProps = {
   year: number;
   month: number;
+  evaluations: Evaluation[];
 };
 
 function getMonthWeekRange(year: number, month: number): { start: Date; end: Date } {
@@ -20,7 +22,7 @@ function getMonthWeekRange(year: number, month: number): { start: Date; end: Dat
   return { start, end };
 }
 
-const WeekView: React.FC<WeekViewProps> = ({year, month}) => {
+const WeekView: React.FC<WeekViewProps> = ({ year, month, evaluations }) => {
   const weeklyData = useMemo(() => {
     const { start, end } = getMonthWeekRange(year, month);
     const weeks: { weekLabel: string; count: number }[] = [];
@@ -31,18 +33,24 @@ const WeekView: React.FC<WeekViewProps> = ({year, month}) => {
       const weekEnd = new Date(cursor);
       weekEnd.setDate(weekStart.getDate() + 6);
 
+      const count = evaluations.filter((e) => {
+        const d = e.dueDate;
+        return d >= weekStart && d <= weekEnd;
+      }).length;
+
       const label = `${weekStart.toLocaleDateString()} - ${weekEnd.toLocaleDateString()}`;
 
       weeks.push({
         weekLabel: label,
-        count: 0,
+        count,
       });
 
       cursor.setDate(cursor.getDate() + 7);
     }
 
     return weeks;
-  }, [year, month]);
+  }, [evaluations, year, month]);
+
   return (
     <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
       {weeklyData.map(({ weekLabel, count }) => (


### PR DESCRIPTION
## WeekView Component

This PR adds the WeekView component and use it in the heatmap page.

### Purpose

WeekView displays weekly evaluation counts for a given year and month. It shows all natural weeks covering the selected month (starting on Monday and ending on Sunday), even if some days are from adjacent months.