### PR TITLE
Enhancement: Instructor Submission Status Integration in CalendarView

### DIFF
--- a/src/Evaluation/EvaluationCalendar/CalendarView/CalendarView.tsx
+++ b/src/Evaluation/EvaluationCalendar/CalendarView/CalendarView.tsx
@@ -6,6 +6,7 @@ import MonthlyView from "../MonthlyView/MonthlyView";
 import { Evaluation } from "../../EvaluationService";
 import Button from "../../../Components/Button/Button"; 
 import { filterEvaluations, FilterOptions } from "./FilterEvaluation";
+import { getInstructorSubmissionStatus } from "../../EvaluationService/SubmissionStatus";
 
 interface CalendarViewProps {
   evaluations: Evaluation[];
@@ -45,7 +46,6 @@ const CalendarView: React.FC<CalendarViewProps> = ({
 
     filteredEvaluations.forEach((ev) => {
       const dateKey = ev.dueDate.toISOString().split("T")[0];
-
       if (!grouped[dateKey]) grouped[dateKey] = [];
       grouped[dateKey].push(ev);
     });
@@ -54,6 +54,19 @@ const CalendarView: React.FC<CalendarViewProps> = ({
 
     return { groupedByDate: grouped, sortedDates: sorted };
   }, [filteredEvaluations]);
+
+  const submissionStatus = useMemo(() => {
+    if (!selectedInstructor) return null;
+    const statusMap = getInstructorSubmissionStatus(evaluations, [selectedInstructor]);
+    return statusMap[selectedInstructor];
+  }, [evaluations, selectedInstructor]);
+
+  const statusColor = {
+    'Not Started': 'text-red-500',
+    'Incomplete': 'text-yellow-500',
+    'Needs Fixing': 'text-orange-500',
+    'Submitted': 'text-green-600',
+  }[submissionStatus || 'Not Started'];
 
   const showNoEvaluationsMessage =
     view === "weekly" && sortedDates.length === 0;
@@ -81,44 +94,45 @@ const CalendarView: React.FC<CalendarViewProps> = ({
           label="Monthly"
           disabled={view === "monthly"}
         />
-
-      <div className="space-y-4">
-        {sortedDates.map((isoDate) => {
-          const displayDate = new Intl.DateTimeFormat("en-US", {
-            weekday: "short",
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-            timeZone: "America/Toronto",
-          }).format(new Date(isoDate));
-
-          return (
-            <CalendarDayCard
-              key={isoDate}
-              date={displayDate}
-              evaluations={groupedByDate[isoDate]}
-            />
-          );
-        })}
-        </div>
-
       </div>
 
-      {showNoEvaluationsMessage ? (
+      {selectedInstructor && submissionStatus && (
+        <div className="text-center mt-2">
+          <span className={`text-sm font-semibold ${statusColor}`}>
+            Submission Status: {submissionStatus}
+          </span>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {view === "weekly" && !showNoEvaluationsMessage && (
+          sortedDates.map((isoDate) => {
+            const displayDate = new Intl.DateTimeFormat("en-US", {
+              weekday: "short",
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+              timeZone: "America/Toronto",
+            }).format(new Date(isoDate));
+
+            return (
+              <CalendarDayCard
+                key={isoDate}
+                date={displayDate}
+                evaluations={groupedByDate?.[isoDate] ?? []}
+              />
+            );
+          })
+        )}
+      </div>
+
+      {showNoEvaluationsMessage && (
         <p className="text-center text-gray-500 italic">
           No evaluations scheduled
         </p>
-      ) : view === "weekly" ? (
-        <div className="space-y-4">
-          {sortedDates.map((dateStr) => (
-            <CalendarDayCard
-              key={dateStr}
-              date={dateStr}
-              evaluations={groupedByDate[dateStr]}
-            />
-          ))}
-        </div>
-      ) : (
+      )}
+
+      {view === "monthly" && (
         <MonthlyView evaluations={evaluations} year={year} month={month} />
       )}
     </div>

--- a/src/Evaluation/EvaluationService/SubmissionStatus.test.ts
+++ b/src/Evaluation/EvaluationService/SubmissionStatus.test.ts
@@ -1,0 +1,59 @@
+describe('getInstructorSubmissionStatus', () => {
+  it('should return "Not Started" when no evaluations exist', () => {
+    const result = getInstructorSubmissionStatus([], ['alice@uni.edu']);
+    expect(result['alice@uni.edu']).toBe('Not Started');
+  });
+
+  it('should return "Submitted" when evaluations are complete and valid', () => {
+    const evaluations: Evaluation[] = [
+      { ...validEvaluation, instructor: 'alice@uni.edu' }
+    ];
+    const result = getInstructorSubmissionStatus(evaluations, ['alice@uni.edu']);
+    expect(result['alice@uni.edu']).toBe('Submitted');
+  });
+
+  it('should return "Incomplete" when evaluation is missing required fields', () => {
+    const incompleteEval: Evaluation = {
+      ...validEvaluation,
+      course: '',
+      instructor: 'bob@uni.edu'
+    };
+    const result = getInstructorSubmissionStatus([incompleteEval], ['bob@uni.edu']);
+    expect(result['bob@uni.edu']).toBe('Incomplete');
+  });
+
+  it('should return "Needs Fixing" when evaluation has invalid weight', () => {
+    const invalidEval: Evaluation = {
+      ...validEvaluation,
+      weight: 150,
+      instructor: 'carol@uni.edu'
+    };
+    const result = getInstructorSubmissionStatus([invalidEval], ['carol@uni.edu']);
+    expect(result['carol@uni.edu']).toBe('Needs Fixing');
+  });
+
+  it('should return "Needs Fixing" for invalid due date', () => {
+    const invalidDateEval: Evaluation = {
+      ...validEvaluation,
+      dueDate: new Date('invalid'), 
+      instructor: 'dan@uni.edu'
+    };
+    const result = getInstructorSubmissionStatus([invalidDateEval], ['dan@uni.edu']);
+    expect(result['dan@uni.edu']).toBe('Needs Fixing');
+  });
+
+  
+
+  it('should handle multiple instructors correctly', () => {
+    const evaluations: Evaluation[] = [
+      { ...validEvaluation, instructor: 'a@uni.edu' },
+      { ...validEvaluation, instructor: 'b@uni.edu', weight: 200 }, 
+      { ...validEvaluation, instructor: 'c@uni.edu', course: '' }, 
+    ];
+
+    const result = getInstructorSubmissionStatus(evaluations, [
+      'a@uni.edu',
+      'b@uni.edu',
+      'c@uni.edu',
+      'd@uni.edu'
+    ]);

--- a/src/Evaluation/EvaluationService/SubmissionStatus.test.ts
+++ b/src/Evaluation/EvaluationService/SubmissionStatus.test.ts
@@ -69,3 +69,10 @@ describe('getInstructorSubmissionStatus', () => {
       'c@uni.edu',
       'd@uni.edu'
     ]);
+
+    expect(result['a@uni.edu']).toBe('Submitted');
+    expect(result['b@uni.edu']).toBe('Needs Fixing');
+    expect(result['c@uni.edu']).toBe('Incomplete');
+    expect(result['d@uni.edu']).toBe('Not Started');
+  });
+});

--- a/src/Evaluation/EvaluationService/SubmissionStatus.test.ts
+++ b/src/Evaluation/EvaluationService/SubmissionStatus.test.ts
@@ -1,3 +1,15 @@
+import { getInstructorSubmissionStatus, SubmissionStatus } from './SubmissionStatus';
+import { Evaluation, EvaluationType } from '../EvaluationService';
+
+const validEvaluation: Omit<Evaluation, 'instructor'> = {
+  course: "COMP101",
+  title: "Assignment 1",
+  type: "Assignment" as EvaluationType,
+  weight: 20,
+  dueDate: new Date("2025-09-15"),
+  campus: "Main"
+};
+
 describe('getInstructorSubmissionStatus', () => {
   it('should return "Not Started" when no evaluations exist', () => {
     const result = getInstructorSubmissionStatus([], ['alice@uni.edu']);

--- a/src/Evaluation/EvaluationService/SubmissionStatus.ts
+++ b/src/Evaluation/EvaluationService/SubmissionStatus.ts
@@ -8,5 +8,32 @@ export function getInstructorSubmissionStatus(
 ): Record<string, SubmissionStatus> {
   const statusMap: Record<string, SubmissionStatus> = {};
 
+  for (const instructor of instructors) {
+    const instructorEvaluations = allEvaluations.filter(ev => ev.instructor === instructor);
+
+    if (instructorEvaluations.length === 0) {
+      statusMap[instructor] = 'Not Started';
+    } else if (instructorEvaluations.some(ev => isInvalid(ev))) {
+      statusMap[instructor] = 'Needs Fixing';
+    } else if (instructorEvaluations.some(ev => isIncomplete(ev))) {
+      statusMap[instructor] = 'Incomplete';
+    } else {
+      statusMap[instructor] = 'Submitted';
+    }
+  }
+
   return statusMap;
+}
+
+function isIncomplete(ev: Evaluation): boolean {
+  return !ev.course || !ev.type || !ev.dueDate;
+}
+
+function isInvalid(ev: Evaluation): boolean {
+  return ev.weight < 0 || ev.weight > 100 || !isValidDate(ev.dueDate);
+}
+
+function isValidDate(date: string | Date): boolean {
+  const parsed = new Date(date);
+  return !isNaN(parsed.getTime());
 }

--- a/src/Evaluation/EvaluationService/SubmissionStatus.ts
+++ b/src/Evaluation/EvaluationService/SubmissionStatus.ts
@@ -1,0 +1,12 @@
+import { Evaluation } from './EvaluationService';
+
+export type SubmissionStatus = 'Not Started' | 'Incomplete' | 'Needs Fixing' | 'Submitted';
+
+export function getInstructorSubmissionStatus(
+  allEvaluations: Evaluation[],
+  instructors: string[]
+): Record<string, SubmissionStatus> {
+  const statusMap: Record<string, SubmissionStatus> = {};
+
+  return statusMap;
+}


### PR DESCRIPTION
###  Description

This PR enhances the `CalendarView` component by adding a **color-coded submission status badge** that visually indicates the instructor's evaluation submission state. The implementation relies on the improved `getInstructorSubmissionStatus` utility function which now robustly handles multiple instructors and validates evaluation data accurately.

---

###  What’s Included

#### **`SubmissionStatus.ts`**

* Exported `getInstructorSubmissionStatus` function to compute submission status per instructor.
* Submission statuses include:

  * `Not Started`
  * `Incomplete`
  * `Needs Fixing`
  * `Submitted`
* Validation checks:

  * Required fields: `course`, `type`, `dueDate`
  * Weight within valid range (0–100)
  * Valid `Date` object for due date

#### **`SubmissionStatus.test.ts`**

* Comprehensive unit tests covering:

  * Status determination for all cases:

    * No evaluations (`Not Started`)
    * Complete and valid evaluations (`Submitted`)
    * Missing required fields (`Incomplete`)
    * Invalid weights or dates (`Needs Fixing`)
    * Correct handling of **multiple instructors**, validating individual statuses per instructor

#### **`CalendarView.tsx`**

* Integrated `getInstructorSubmissionStatus` to calculate status dynamically based on `selectedInstructor`.
* Conditionally renders a color-coded status badge with the following mappings:

  * Red: `Not Started`
  * Yellow: `Incomplete`
  * Orange: `Needs Fixing`
  * Green: `Submitted`
* Ensures badge is only displayed when an instructor is selected.
* Improved JSX and className handling for clear, maintainable styling.

---

###  Usage

When a `selectedInstructor` is chosen, the `CalendarView` component provides immediate visual feedback on the submission progress of that instructor’s evaluations, helping instructors quickly identify statuses and take necessary action.

---

###  Related Issue

Closes: #626

---