### PR TITLE
Feature/295 delete evaluation

### DIFF
--- a/src/Evaluation/EvaluationCalendar/CalendarView/CalendarView.tsx
+++ b/src/Evaluation/EvaluationCalendar/CalendarView/CalendarView.tsx
@@ -1,11 +1,12 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { CalendarNavigation } from "../../../Components/CalendarNavigation";
 import { useCalendarNavigation } from "../useCalendarNavigation";
 import CalendarDayCard from "../../../Components/CalendarDayCard";
 import MonthlyView from "../MonthlyView/MonthlyView";
-import { Evaluation } from "../../EvaluationService";
+import { Evaluation, EvaluationService } from "../../EvaluationService";
 import Button from "../../../Components/Button/Button"; 
 import { filterEvaluations, FilterOptions } from "./FilterEvaluation";
+import { LocalStorage } from "../../../localStorageService";
 
 interface CalendarViewProps {
   evaluations: Evaluation[];
@@ -22,6 +23,22 @@ const CalendarView: React.FC<CalendarViewProps> = ({
 }) => {
   const [view, setView] = useState<"weekly" | "monthly">("weekly");
 
+  const [allEvaluations, setAllEvaluations] = useState<Evaluation[]>([]);
+  const service = useMemo(() => new EvaluationService(new LocalStorage()), []);
+
+  useEffect(() => {
+    setAllEvaluations(evaluations);
+  }, [evaluations]);
+
+  const handleDeleteEvaluation = (target: Evaluation) => {
+    try {
+      const updated = service.deleteEvaluation(target);
+      setAllEvaluations(updated);
+    } catch (err) {
+      console.error("Failed to delete evaluation:", err);
+    }
+  };
+
   const {
     startDate,
     year,
@@ -37,8 +54,8 @@ const CalendarView: React.FC<CalendarViewProps> = ({
       type: selectedType,
       date: selectedDate,
     };
-    return filterEvaluations(evaluations, filters);
-  }, [evaluations, selectedInstructor, selectedType, selectedDate]);
+    return filterEvaluations(allEvaluations, filters); 
+  }, [allEvaluations, selectedInstructor, selectedType, selectedDate]);
 
   const { groupedByDate, sortedDates } = useMemo(() => {
     const grouped: Record<string, Evaluation[]> = {};
@@ -81,27 +98,6 @@ const CalendarView: React.FC<CalendarViewProps> = ({
           label="Monthly"
           disabled={view === "monthly"}
         />
-
-      <div className="space-y-4">
-        {sortedDates.map((isoDate) => {
-          const displayDate = new Intl.DateTimeFormat("en-US", {
-            weekday: "short",
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-            timeZone: "America/Toronto",
-          }).format(new Date(isoDate));
-
-          return (
-            <CalendarDayCard
-              key={isoDate}
-              date={displayDate}
-              evaluations={groupedByDate[isoDate]}
-            />
-          );
-        })}
-        </div>
-
       </div>
 
       {showNoEvaluationsMessage ? (
@@ -115,11 +111,12 @@ const CalendarView: React.FC<CalendarViewProps> = ({
               key={dateStr}
               date={dateStr}
               evaluations={groupedByDate[dateStr]}
+              onDeleteEvaluation={handleDeleteEvaluation}  
             />
           ))}
         </div>
       ) : (
-        <MonthlyView evaluations={evaluations} year={year} month={month} />
+        <MonthlyView evaluations={allEvaluations} year={year} month={month} /> 
       )}
     </div>
   );

--- a/src/Evaluation/EvaluationService/EvaluationService.test.ts
+++ b/src/Evaluation/EvaluationService/EvaluationService.test.ts
@@ -67,5 +67,30 @@ describe('EvaluationService', () => {
 
       expect(() => service.loadEvaluations()).toThrow('Failed to load evaluations');
     });
+     describe('deleteEvaluation', () => {
+    it('should delete a matching evaluation', () => {
+      service.saveEvaluations(sampleData);
+      const updated = service.deleteEvaluation(sampleData[0]);
+      expect(updated).toEqual([]);
+    });
+
+    it('should not delete if no exact match is found', () => {
+      service.saveEvaluations(sampleData);
+      const nonMatching: Evaluation = {
+        ...sampleData[0],
+        title: 'Different Title', // change to force mismatch
+      };
+      const updated = service.deleteEvaluation(nonMatching);
+      expect(updated).toEqual(sampleData);
+    });
+
+    it('should throw an error if load or save fails during delete', () => {
+      service.saveEvaluations(sampleData);
+      storage.load = () => {
+        throw new Error('Mock load error');
+      };
+      service = new EvaluationService(storage);
+      expect(() => service.deleteEvaluation(sampleData[0])).toThrow('Failed to delete evaluation');
+    });
   });
 });

--- a/src/Evaluation/EvaluationService/EvaluationService.ts
+++ b/src/Evaluation/EvaluationService/EvaluationService.ts
@@ -54,5 +54,30 @@ export class EvaluationService implements IEvaluationService {
       console.error('Failed to load evaluations:', error);
       throw new Error('Failed to load evaluations');
     }
+    
+  }
+   deleteEvaluation(target: Evaluation): Evaluation[] {
+    try {
+      const data = this.loadEvaluations();
+      const targetDate = new Date(target.dueDate).toDateString();
+
+      const updated = data.filter(ev =>
+        !(
+          ev.title === target.title &&
+          ev.course === target.course &&
+          ev.type === target.type &&
+          new Date(ev.dueDate).toDateString() === targetDate &&
+          ev.instructor === target.instructor &&
+          ev.campus === target.campus &&
+          ev.weight === target.weight
+        )
+      );
+
+      this.saveEvaluations(updated);
+      return updated;
+    } catch (error) {
+      console.error('Failed to delete evaluation:', error);
+      throw new Error('Failed to delete evaluation');
+    }
   }
 }


### PR DESCRIPTION
# Implement Delete Evaluation Functionality (#295)

This PR implements the ability to delete individual evaluations from local storage and reflect those changes in the calendar view.

## Changes Made

###  `EvaluationService.test.ts`
- Added new test block for `deleteEvaluation` method
- Covers:
  - Successful deletion
  - Error handling when `load` or `save` fails

###  `EvaluationService.ts`
- Added `deleteEvaluation(target: Evaluation)` method
- Deletes an evaluation by matching all fields (title, course, type, date, weight, instructor, campus)
- Saves updated list to localStorage

###  `CalendarView.tsx`
- Introduced `allEvaluations` state to manage deletions
- Synced `evaluations` prop to state using `useEffect`
- Created `handleDeleteEvaluation()` to call the service method and update state
- Replaced `evaluations` usage with `allEvaluations` in filtering and views
- Passed `onDeleteEvaluation` prop to `CalendarDayCard`


## 🔗 Related Issue

Closes #295
