### PR TITLE
fix/663: correct Tailwind plugin usage in postcss.config.js

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
### Summary
This PR fixes the incorrect usage of the Tailwind CSS plugin in the `postcss.config.js` file.

### Changes
- Replaced invalid plugin name `@tailwindcss/postcss` with the correct `tailwindcss`.
- Ensures Tailwind CSS utilities are properly loaded via PostCSS.

### Testing
- Verified Tailwind utility classes apply correctly in the application UI after the fix.

### Before
<img width="1257" height="887" alt="image" src="https://github.com/user-attachments/assets/233c403e-3ddd-4e6c-bd8d-37213a505f1d" />


### After
<img width="1254" height="763" alt="image" src="https://github.com/user-attachments/assets/8d3ff0ab-34b8-4a83-abfc-7ce345d1240c" />

### Testing Instructions
- npm install
- npm run dev

### Linked Issue
Closes #663 
