### PR TITLE
Issue 658 Configure '@' Path Alias and Refactor Imports in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import logo from './assets/logo.png';
-import ModuleNotFound from './Components/ModuleNotFound'; 
-import EnrollmentDashboard from './Enrollment/Dashboard/Dashboard';
-import EvaluationCard from '../src/Dashboard/EvaluationCard';
+import logo from '@/assets/logo.png';
+import ModuleNotFound from '@/Components/ModuleNotFound'; 
+import EnrollmentDashboard from '@/Enrollment/Dashboard/Dashboard';
+import EvaluationCard from '@/Dashboard/EvaluationCard';
 function App() {
   return (
     <BrowserRouter>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,7 +17,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    }
   },
   "include": ["src", "electron"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Description
This PR implements path aliasing in the SQATE project to replace long relative imports with cleaner, maintainable `@/` imports.

## Changes Made
- Configured `baseUrl` and `paths` in `tsconfig.json` and `tsconfig.app.json` to support `@/` as an alias for `src/`.
- Confirmed that `vite.config.ts` already includes the `@` alias configuration.
- Refactored imports in `App.tsx` to use the `@/` alias instead of relative paths.

## Impact
- Simplified import paths, reducing potential errors from deep relative imports.
- Improved code readability and maintainability.

## Tasks Completed
- [x] Configure `baseUrl` and `paths` in `tsconfig.json`
- [x] Configure `baseUrl` and `paths` in `tsconfig.app.json`
- [x] Verify `vite.config.ts` alias settings
- [x] Refactor imports in `App.tsx`
- [x] Build and test project to ensure no breakage

## Testing Steps

### Verify routing
- Navigate to `/` → Home page loads with logo and title.
- Navigate to `/enrollment` → `EnrollmentDashboard` component loads correctly.
- Navigate to `/evaluation` → `EvaluationCard` component loads correctly.

### Check error route
- Navigate to a non-existent route (e.g., `/random`) → `ModuleNotFound` component displays.

### Run build command
- npm run build
- Ensure build completes successfully without alias-related errors.

## Linked Issues
- Closes #658 