### PR TITLE
Refactor: Centralized EvaluationCalendar Styling & Dark Mode Support

### DIFF
--- a/src/Components/CalendarDayCard/CalendarDayCard.tsx
+++ b/src/Components/CalendarDayCard/CalendarDayCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { evaluationCalendarStyles as styles } from "../../Evaluation/EvaluationCalendar/Styles/evaluationCalendarStyles";
 
 const CalendarDayCard: React.FC<{
     date: string;
@@ -11,22 +12,22 @@ const CalendarDayCard: React.FC<{
     }[];
 }> = ({ date, evaluations }) => {
     return (
-        <div className="bg-white shadow rounded p-4">
-            <h2 className="text-xl font-bold mb-2">{date}</h2>
+        <div className={styles.dayCard}>
+            <h2 className={styles.dayCardHeader}>{date}</h2>
 
             {evaluations.length === 0 ? (
-                <p className="text-sm text-gray-500 italic">No evaluations scheduled for this day.</p>
+                <p className={styles.dayCardEmpty}>No evaluations scheduled for this day.</p>
             ) : (
-                <ul className="space-y-2">
+                <ul className={styles.dayCardList}>
                     {evaluations.map((ev, idx) => (
                         <li
                             key={idx}
-                            className="border border-gray-200 rounded p-2 hover:bg-gray-50"
+                            className={styles.dayCardItem}
                         >
-                            <div className="text-sm font-semibold">
+                            <div className={styles.dayCardItemTitle}>
                                 {ev.title} ({ev.type})
                             </div>
-                            <div className="text-xs text-gray-600">
+                            <div className={styles.dayCardItemMeta}>
                                 Course: {ev.course} | Weight: {ev.weight}%
                             </div>
                         </li>

--- a/src/Evaluation/EvaluationCalendar/CalendarView/CalendarView.tsx
+++ b/src/Evaluation/EvaluationCalendar/CalendarView/CalendarView.tsx
@@ -6,6 +6,7 @@ import MonthlyView from "../MonthlyView/MonthlyView";
 import { Evaluation } from "../../EvaluationService";
 import Button from "../../../Components/Button/Button"; 
 import { filterEvaluations, FilterOptions } from "./FilterEvaluation";
+import { evaluationCalendarStyles as styles } from "../Styles/evaluationCalendarStyles";
 
 interface CalendarViewProps {
   evaluations: Evaluation[];
@@ -58,8 +59,23 @@ const CalendarView: React.FC<CalendarViewProps> = ({
   const showNoEvaluationsMessage =
     view === "weekly" && sortedDates.length === 0;
 
+  const toggleDarkMode = () => {
+    document.documentElement.classList.toggle("dark");
+  };
+
   return (
-    <div className="space-y-4">
+    <div className={styles.calendarViewContainer}>
+      {/* Dark mode toggle */}
+      <div className="flex justify-end">
+        <button
+          onClick={toggleDarkMode}
+          className="text-sm px-3 py-1 rounded-md border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700 transition"
+        >
+          Toggle Dark Mode
+        </button>
+      </div>
+
+      {/* Navigation */}
       <CalendarNavigation
         label={getLabel(view)}
         onPrev={() =>
@@ -70,53 +86,48 @@ const CalendarView: React.FC<CalendarViewProps> = ({
         }
       />
 
-      <div className="flex justify-center gap-4">
-        <Button
+      {/* View Toggle */}
+      <div className={styles.viewToggleWrapper}>
+        <button
+          className={styles.viewToggleButton(view === "weekly")}
           onClick={() => setView("weekly")}
-          label="Weekly"
           disabled={view === "weekly"}
-        />
-        <Button
+        >
+          Weekly
+        </button>
+        <button
+          className={styles.viewToggleButton(view === "monthly")}
           onClick={() => setView("monthly")}
-          label="Monthly"
           disabled={view === "monthly"}
-        />
-
-      <div className="space-y-4">
-        {sortedDates.map((isoDate) => {
-          const displayDate = new Intl.DateTimeFormat("en-US", {
-            weekday: "short",
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-            timeZone: "America/Toronto",
-          }).format(new Date(isoDate));
-
-          return (
-            <CalendarDayCard
-              key={isoDate}
-              date={displayDate}
-              evaluations={groupedByDate[isoDate]}
-            />
-          );
-        })}
-        </div>
-
+        >
+          Monthly
+        </button>
       </div>
 
+      {/* Content */}
       {showNoEvaluationsMessage ? (
-        <p className="text-center text-gray-500 italic">
+        <p className={styles.noEvaluationsMessage}>
           No evaluations scheduled
         </p>
       ) : view === "weekly" ? (
-        <div className="space-y-4">
-          {sortedDates.map((dateStr) => (
-            <CalendarDayCard
-              key={dateStr}
-              date={dateStr}
-              evaluations={groupedByDate[dateStr]}
-            />
-          ))}
+        <div className={styles.cardSection}>
+          {sortedDates.map((dateStr) => {
+            const displayDate = new Intl.DateTimeFormat("en-US", {
+              weekday: "short",
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+              timeZone: "America/Toronto",
+            }).format(new Date(dateStr));
+
+            return (
+              <CalendarDayCard
+                key={dateStr}
+                date={displayDate}
+                evaluations={groupedByDate[dateStr]}
+              />
+            );
+          })}
         </div>
       ) : (
         <MonthlyView evaluations={evaluations} year={year} month={month} />
@@ -124,5 +135,6 @@ const CalendarView: React.FC<CalendarViewProps> = ({
     </div>
   );
 };
+
 
 export default CalendarView;

--- a/src/Evaluation/EvaluationCalendar/MonthlyView/MonthlyView.tsx
+++ b/src/Evaluation/EvaluationCalendar/MonthlyView/MonthlyView.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import CalendarDayCard from "../../../Components/CalendarDayCard";
 import { Evaluation } from "../../EvaluationService";
+import { evaluationCalendarStyles as styles } from "../Styles/evaluationCalendarStyles";
 
 interface MonthlyViewProps {
   evaluations: Evaluation[];
@@ -42,7 +43,7 @@ const MonthlyView: React.FC<MonthlyViewProps> = ({ evaluations, month, year }) =
     return(
           <div className="space-y-2">
       {!hasAnyEvaluations && (
-        <div className="text-center text-gray-500 italic p-2">
+        <div className={styles.noEvaluationsMessage}>
           No evaluations are scheduled for this month.
         </div>
       )}
@@ -52,12 +53,12 @@ const MonthlyView: React.FC<MonthlyViewProps> = ({ evaluations, month, year }) =
   
   return (
     <div className="space-y-2">
-      <div className="grid grid-cols-7 text-center font-bold text-sm">
+      <div className="grid grid-cols-7 text-center font-bold text-sm text-gray-700 dark:text-gray-200">
         {daysInWeek.map((day) => (
           <div key={day}>{day}</div>
         ))}
       </div>
-      <div className="grid grid-cols-7 gap-2">
+      <div className={styles.monthlyGrid}>
         {calendarCells.map(({ date, evaluations }, idx) => (
           <div key={idx} role="gridcell">
             {!isNaN(date.getTime()) ? (

--- a/src/Evaluation/EvaluationCalendar/Styles/evaluationCalendarStyles.ts
+++ b/src/Evaluation/EvaluationCalendar/Styles/evaluationCalendarStyles.ts
@@ -1,0 +1,53 @@
+export const evaluationCalendarStyles = {
+  // Main Calendar Container Styles
+  calendarViewContainer:
+    "space-y-6 p-6 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-2xl shadow-xl transition-colors duration-300",
+
+  // Navigation + View Toggle Styles
+  navSection: "flex justify-between items-center",
+
+  viewToggleWrapper: "flex justify-center gap-4",
+
+  viewToggleButton: (active: boolean) =>
+    `px-5 py-2 text-sm font-medium rounded-xl transition duration-200 ${
+      active
+        ? "bg-blue-600 text-white shadow"
+        : "bg-white text-blue-600 border border-blue-600 hover:bg-blue-50 dark:bg-gray-800 dark:text-blue-400 dark:border-blue-400 dark:hover:bg-gray-700"
+    }`,
+
+  // Fallback Message for No Evaluation Styles
+  noEvaluationsMessage:
+    "text-center text-gray-500 dark:text-gray-400 italic mt-6",
+
+  // Calendar Day Card Styles
+  cardSection: "space-y-4",
+
+  dayCard: "bg-white dark:bg-gray-800 shadow rounded-xl p-4 border-l-4 border-blue-500 dark:border-blue-400 transition-all",
+
+  dayCardHeader: "text-xl font-bold text-blue-700 dark:text-blue-300 mb-2",
+
+  dayCardEmpty: "text-sm text-gray-500 dark:text-gray-400 italic",
+
+  dayCardList: "space-y-2",
+
+  dayCardItem: "border border-gray-200 dark:border-gray-600 rounded p-2 hover:bg-gray-50 dark:hover:bg-gray-700",
+
+  dayCardItemTitle: "text-sm font-semibold text-gray-800 dark:text-gray-100",
+
+  dayCardItemMeta: "text-xs text-gray-600 dark:text-gray-400",
+
+  // Weekly View Grid Styles
+  weeklyGrid: "grid grid-cols-1 sm:grid-cols-7 gap-4",
+
+  weeklyDayWrapper: "flex flex-col gap-2",
+
+  // Monthly View Grid Styles
+  monthlyGrid: "grid grid-cols-1 sm:grid-cols-7 gap-4",
+
+  monthlyDayBox:
+    "min-h-[140px] border border-gray-200 dark:border-gray-700 p-2 rounded-xl bg-gray-50 dark:bg-gray-800 hover:bg-blue-50 dark:hover:bg-gray-700 transition-all",
+
+  monthlyDateLabel: "text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2",
+
+  monthlyEvalTitle: "text-xs text-gray-700 dark:text-gray-300 truncate",
+};


### PR DESCRIPTION
This PR introduces a centralized Tailwind styling file for all components under `EvaluationCalendar`, and adds full dark mode support using Tailwind's `dark:` variant.

- Created `EvaluationCalendarStyles.ts` in `EvaluationCalendar/`
- Moved all Tailwind class strings from:
  - CalendarView.tsx
  - MonthlyView.tsx
  - CalendarDayCard.tsx

- Added `dark:` variants for background, text, border, and hover states
- Verified consistent UI in both light and dark modes