### PR TITLE
feat: add funtion to get counts by evaluation

### DIFF
--- a/src/Evaluation/Heatmap/getEvaluationCountsByType.test.tsx
+++ b/src/Evaluation/Heatmap/getEvaluationCountsByType.test.tsx
@@ -1,0 +1,68 @@
+import { getEvaluationCountsByType } from './getEvaluationCountsByType';
+import { Evaluation, EvaluationType } from '../EvaluationService';
+
+describe('getEvaluationCountsByType', () => {
+  const baseEvaluation = {
+    course: 'CS101',
+    title: 'Sample',
+    weight: 10,
+    dueDate: new Date('2025-01-01'),
+    instructor: 'Dr. Smith',
+    campus: 'Waterloo',
+  };
+
+  it('should return 0 for all types when evaluations is empty', () => {
+    const evaluations: Evaluation[] = [];
+    const result = getEvaluationCountsByType(evaluations);
+
+    expect(result).toEqual({
+      Assignment: 0,
+      'Mid Exam': 0,
+      Quiz: 0,
+      Project: 0,
+      'Practical Lab': 0,
+      'Final Exam': 0,
+    });
+  });
+
+  it('should count one of each evaluation type correctly', () => {
+    const evaluations: Evaluation[] = [
+      { ...baseEvaluation, type: 'Assignment' },
+      { ...baseEvaluation, type: 'Mid Exam' },
+      { ...baseEvaluation, type: 'Quiz' },
+      { ...baseEvaluation, type: 'Project' },
+      { ...baseEvaluation, type: 'Practical Lab' },
+      { ...baseEvaluation, type: 'Final Exam' },
+    ];
+
+    const result = getEvaluationCountsByType(evaluations);
+
+    expect(result).toEqual({
+      Assignment: 1,
+      'Mid Exam': 1,
+      Quiz: 1,
+      Project: 1,
+      'Practical Lab': 1,
+      'Final Exam': 1,
+    });
+  });
+
+  it('should correctly count repeated types', () => {
+    const evaluations: Evaluation[] = [
+      { ...baseEvaluation, type: 'Assignment' },
+      { ...baseEvaluation, type: 'Assignment' },
+      { ...baseEvaluation, type: 'Quiz' },
+    ];
+
+    const result = getEvaluationCountsByType(evaluations);
+
+    expect(result).toEqual({
+      Assignment: 2,
+      'Mid Exam': 0,
+      Quiz: 1,
+      Project: 0,
+      'Practical Lab': 0,
+      'Final Exam': 0,
+    });
+  });
+});

--- a/src/Evaluation/Heatmap/getEvaluationCountsByType.tsx
+++ b/src/Evaluation/Heatmap/getEvaluationCountsByType.tsx
@@ -1,0 +1,18 @@
+import { Evaluation, EvaluationType } from "../EvaluationService";
+
+export function getEvaluationCountsByType(evaluations: Evaluation[]): Record<EvaluationType, number> {
+  const counts: Record<EvaluationType, number> = {
+    Assignment: 0,
+    'Mid Exam': 0,
+    Quiz: 0,
+    Project: 0,
+    'Practical Lab': 0,
+    'Final Exam': 0,
+  };
+
+  evaluations.forEach((e) => {
+    counts[e.type]++;
+  });
+
+  return counts;
+}


### PR DESCRIPTION
## 📝 PR: Add function to Count Evaluations by Type

### Summary

This pull request introduces a new utility function `getEvaluationCountsByType` which processes an array of `Evaluation` objects and returns the count of each `EvaluationType`.

### ✅ What’s Included

- A new function: `getEvaluationCountsByType(evaluations: Evaluation[])`
- Returns a `Record<EvaluationType, number>` containing the total count for each of the following types:
  - `Assignment`
  - `Quiz`
  - `Project`
  - `Mid Exam`
  - `Final Exam`
  - `Practical Lab`

### 📌 Purpose

This function enables future features such as:
- Summary dashboards
- Visual analytics (e.g., bar charts or pie charts)
- Quick filtering and statistics generation in the UI