### PR TITLE
feature/evaluation-type-breakdown-by-colourcode

### DIFF
--- a/src/Evaluation/Heatmap/EvaluationTypeBreakdown.test.tsx
+++ b/src/Evaluation/Heatmap/EvaluationTypeBreakdown.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EvaluationTypeBreakdown from './EvaluationTypeBreakdown';
+import { EvaluationType, Evaluation } from '../EvaluationService';
+
+const createEval = (type: EvaluationType): Evaluation => ({
+  course: 'Test Course',
+  title: 'Test Title',
+  type: type,
+  weight: 10,
+  dueDate: new Date(),
+  instructor: 'X',
+  campus: 'Main',
+});
+
+describe('EvaluationTypeBreakdown component', () => {
+  const typeCounts: Record<EvaluationType, number> = {
+    Assignment: 1,
+    'Mid Exam': 0,
+    Quiz: 2,
+    Project: 0,
+    'Practical Lab': 0,
+    'Final Exam': 1,
+  };
+
+  it('should render only types with count > 0', () => {
+    render(<EvaluationTypeBreakdown typeCounts={typeCounts} />);
+
+    expect(screen.getByText('Assignment: 1')).toBeInTheDocument();
+    expect(screen.getByText('Quiz: 2')).toBeInTheDocument();
+    expect(screen.getByText('Final Exam: 1')).toBeInTheDocument();
+
+    expect(screen.queryByText(/Mid Exam/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Project/)).not.toBeInTheDocument();
+  });
+
+  it('should render correct color class for each type', () => {
+    const { container } = render(<EvaluationTypeBreakdown typeCounts={typeCounts} />);
+
+    expect(container.querySelector('.bg-blue-500')).toBeTruthy(); // Assignment
+    expect(container.querySelector('.bg-green-500')).toBeTruthy(); // Quiz
+    expect(container.querySelector('.bg-red-500')).toBeTruthy(); // Final Exam
+  });
+});

--- a/src/Evaluation/Heatmap/EvaluationTypeBreakdown.tsx
+++ b/src/Evaluation/Heatmap/EvaluationTypeBreakdown.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { EvaluationType, Evaluation } from '../EvaluationService';
+
+const typeColorMap: Record<EvaluationType, string> = {
+  'Assignment': 'bg-blue-500',
+  'Mid Exam': 'bg-orange-500',
+  'Quiz': 'bg-green-500',
+  'Project': 'bg-purple-500',
+  'Practical Lab': 'bg-teal-500',
+  'Final Exam': 'bg-red-500',
+};
+
+type Props = {
+  typeCounts: Record<EvaluationType, number>;
+};
+
+const EvaluationTypeBreakdown: React.FC<Props> = ({ typeCounts }) => {
+  return (
+    <div className="space-y-1 mt-2">
+      {Object.entries(typeCounts).map(([type, count]) =>
+        count > 0 ? (
+          <div
+            key={type}
+            className={`text-sm rounded px-2 py-1 text-white ${typeColorMap[type as EvaluationType]}`}
+          >
+            {type}: {count}
+          </div>
+        ) : null
+      )}
+    </div>
+  );
+};
+
+export default EvaluationTypeBreakdown;


### PR DESCRIPTION


# Summary

This pull request introduces the `EvaluationTypeBreakdown` React component, which displays a breakdown of evaluation types (e.g., Assignment, Quiz, Final Exam) with color-coded badges. It also includes unit tests to validate the component's rendering behavior and styling.

---

##  Features

- Renders evaluation types with a count greater than 0.
- Applies color-coded background classes using Tailwind CSS (`typeColorMap`).
- Dynamic rendering based on `typeCounts` prop.
- Unit tests using React Testing Library.

---

##  Tests Added

- Renders only evaluation types with `count > 0`
- Applies correct color classes per evaluation type
- Test file: `EvaluationTypeBreakdown.test.tsx`

---

## Files Added

- `src/Evaluation/Heatmap/EvaluationTypeBreakdown.tsx`
- `src/Evaluation/Heatmap/EvaluationTypeBreakdown.test.tsx`

---


## Notes

- Evaluation types and their corresponding Tailwind color classes are defined in `typeColorMap`.
- Future enhancement: Support click or filter interaction per evaluation type badge.

---

## Checklist

- [x] Component renders correctly
- [x] Tests cover key functionality and pass
- [x] Code is linted and follows project style guide
- [x] Component does not break any existing functionality

