### PR TITLE
feat: add show color by evaluation type in monthview

### DIFF
--- a/src/Evaluation/Heatmap/EvaluationTypeBreakdown.test.tsx
+++ b/src/Evaluation/Heatmap/EvaluationTypeBreakdown.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EvaluationTypeBreakdown from './EvaluationTypeBreakdown';
+import { EvaluationType, Evaluation } from '../EvaluationService';
+
+const createEval = (type: EvaluationType): Evaluation => ({
+  course: 'Test Course',
+  title: 'Test Title',
+  type: type,
+  weight: 10,
+  dueDate: new Date(),
+  instructor: 'X',
+  campus: 'Main',
+});
+
+describe('EvaluationTypeBreakdown component', () => {
+  const typeCounts: Record<EvaluationType, number> = {
+    Assignment: 1,
+    'Mid Exam': 0,
+    Quiz: 2,
+    Project: 0,
+    'Practical Lab': 0,
+    'Final Exam': 1,
+  };
+
+  it('should render only types with count > 0', () => {
+    render(<EvaluationTypeBreakdown typeCounts={typeCounts} />);
+
+    expect(screen.getByText('Assignment: 1')).toBeInTheDocument();
+    expect(screen.getByText('Quiz: 2')).toBeInTheDocument();
+    expect(screen.getByText('Final Exam: 1')).toBeInTheDocument();
+
+    expect(screen.queryByText(/Mid Exam/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Project/)).not.toBeInTheDocument();
+  });
+
+  it('should render correct color class for each type', () => {
+    const { container } = render(<EvaluationTypeBreakdown typeCounts={typeCounts} />);
+
+    expect(container.querySelector('.bg-blue-500')).toBeTruthy(); // Assignment
+    expect(container.querySelector('.bg-green-500')).toBeTruthy(); // Quiz
+    expect(container.querySelector('.bg-red-500')).toBeTruthy(); // Final Exam
+  });
+});

--- a/src/Evaluation/Heatmap/EvaluationTypeBreakdown.tsx
+++ b/src/Evaluation/Heatmap/EvaluationTypeBreakdown.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { EvaluationType, Evaluation } from '../EvaluationService';
+
+const typeColorMap: Record<EvaluationType, string> = {
+  'Assignment': 'bg-blue-500',
+  'Mid Exam': 'bg-orange-500',
+  'Quiz': 'bg-green-500',
+  'Project': 'bg-purple-500',
+  'Practical Lab': 'bg-teal-500',
+  'Final Exam': 'bg-red-500',
+};
+
+type Props = {
+  typeCounts: Record<EvaluationType, number>;
+};
+
+const EvaluationTypeBreakdown: React.FC<Props> = ({ typeCounts }) => {
+  return (
+    <div className="space-y-1 mt-2">
+      {Object.entries(typeCounts).map(([type, count]) =>
+        count > 0 ? (
+          <div
+            key={type}
+            className={`text-sm rounded px-2 py-1 text-white ${typeColorMap[type as EvaluationType]}`}
+          >
+            {type}: {count}
+          </div>
+        ) : null
+      )}
+    </div>
+  );
+};
+
+export default EvaluationTypeBreakdown;

--- a/src/Evaluation/Heatmap/MonthView.tsx
+++ b/src/Evaluation/Heatmap/MonthView.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from 'react';
+import { Evaluation } from '../EvaluationService';
+import EvaluationTypeBreakdown from './EvaluationTypeBreakdown';
+import { getEvaluationCountsByType } from './getEvaluationCountsByType';
+
+type MonthViewProps = {
+  year: number;
+  evaluations: Evaluation[];
+};
+
+const MonthView: React.FC<MonthViewProps> = ({ year, evaluations }) => {
+  const monthlyData = useMemo(() => {
+    const data: {
+      monthLabel: string;
+      count: number;
+      typeCounts: Record<Evaluation["type"], number>;
+    }[] = [];
+
+    for (let i = 0; i < 12; i++) {
+      const monthStart = new Date(year, i, 1);
+      const monthEnd = new Date(year, i + 1, 1);
+
+      const monthEvaluations = evaluations.filter((e) => {
+        const d = e.dueDate;
+        return d >= monthStart && d < monthEnd;
+      });
+
+      const typeCounts = getEvaluationCountsByType(monthEvaluations);
+      const label = `${monthStart.toLocaleString('default', { month: 'long' })} ${year}`;
+
+      data.push({
+        monthLabel: label,
+        count: monthEvaluations.length,
+        typeCounts,
+      });
+    }
+
+    return data;
+  }, [evaluations, year]);
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+      {monthlyData.map(({ monthLabel, count, typeCounts }) => (
+        <div
+          key={monthLabel}
+          className="rounded p-4 text-center shadow-sm border border-gray-200"
+        >
+          <div className="font-semibold mb-2">{monthLabel}</div>
+          <div className="text-sm font-bold mb-2">
+            {count} evaluations
+          </div>
+          <EvaluationTypeBreakdown typeCounts={typeCounts} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MonthView;

--- a/src/Evaluation/Heatmap/getEvaluationCountsByType.test.tsx
+++ b/src/Evaluation/Heatmap/getEvaluationCountsByType.test.tsx
@@ -1,0 +1,68 @@
+import { getEvaluationCountsByType } from './getEvaluationCountsByType';
+import { Evaluation, EvaluationType } from '../EvaluationService';
+
+describe('getEvaluationCountsByType', () => {
+  const baseEvaluation = {
+    course: 'CS101',
+    title: 'Sample',
+    weight: 10,
+    dueDate: new Date('2025-01-01'),
+    instructor: 'Dr. Smith',
+    campus: 'Waterloo',
+  };
+
+  it('should return 0 for all types when evaluations is empty', () => {
+    const evaluations: Evaluation[] = [];
+    const result = getEvaluationCountsByType(evaluations);
+
+    expect(result).toEqual({
+      Assignment: 0,
+      'Mid Exam': 0,
+      Quiz: 0,
+      Project: 0,
+      'Practical Lab': 0,
+      'Final Exam': 0,
+    });
+  });
+
+  it('should count one of each evaluation type correctly', () => {
+    const evaluations: Evaluation[] = [
+      { ...baseEvaluation, type: 'Assignment' },
+      { ...baseEvaluation, type: 'Mid Exam' },
+      { ...baseEvaluation, type: 'Quiz' },
+      { ...baseEvaluation, type: 'Project' },
+      { ...baseEvaluation, type: 'Practical Lab' },
+      { ...baseEvaluation, type: 'Final Exam' },
+    ];
+
+    const result = getEvaluationCountsByType(evaluations);
+
+    expect(result).toEqual({
+      Assignment: 1,
+      'Mid Exam': 1,
+      Quiz: 1,
+      Project: 1,
+      'Practical Lab': 1,
+      'Final Exam': 1,
+    });
+  });
+
+  it('should correctly count repeated types', () => {
+    const evaluations: Evaluation[] = [
+      { ...baseEvaluation, type: 'Assignment' },
+      { ...baseEvaluation, type: 'Assignment' },
+      { ...baseEvaluation, type: 'Quiz' },
+    ];
+
+    const result = getEvaluationCountsByType(evaluations);
+
+    expect(result).toEqual({
+      Assignment: 2,
+      'Mid Exam': 0,
+      Quiz: 1,
+      Project: 0,
+      'Practical Lab': 0,
+      'Final Exam': 0,
+    });
+  });
+});

--- a/src/Evaluation/Heatmap/getEvaluationCountsByType.tsx
+++ b/src/Evaluation/Heatmap/getEvaluationCountsByType.tsx
@@ -1,0 +1,18 @@
+import { Evaluation, EvaluationType } from "../EvaluationService";
+
+export function getEvaluationCountsByType(evaluations: Evaluation[]): Record<EvaluationType, number> {
+  const counts: Record<EvaluationType, number> = {
+    Assignment: 0,
+    'Mid Exam': 0,
+    Quiz: 0,
+    Project: 0,
+    'Practical Lab': 0,
+    'Final Exam': 0,
+  };
+
+  evaluations.forEach((e) => {
+    counts[e.type]++;
+  });
+
+  return counts;
+}


### PR DESCRIPTION
## 🔄 Enhancement: Monthly Evaluation Breakdown by Type

### Related
This PR is based on and extends the functionality introduced in:
- PR #602 
- PR #677  
- PR #678

### Summary
This PR enhances the `MonthView` component to display a more informative and user-friendly breakdown of evaluations per month. Instead of showing only the total count, each month, now includes a breakdown by evaluation type.

### ✨ What's Changed
- **Data Structure Update**
  - `monthlyData` now includes:
    - `monthLable`: Lable for the month.
    - `count`: Total number of evaluations for the month.
    - `typeCounts`: Breakdown of evaluations grouped by `Evaluation["type"]`.

- **Logic Update**
  - Added monthly filtering logic for evaluations.
  - Used the `getEvaluationCountsByType` utility to compute type-based counts.

- **UI Update**
  - Updated card layout to include:
    - A bold total count of evaluations.
    - The new `<EvaluationTypeBreakdown />` component for type-wise display.
