### PR TITLE
683/feat(electron): open external URLs in default browser using Electron shell

### DIFF
--- a/electron/public/main.cjs
+++ b/electron/public/main.cjs
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu, dialog } = require('electron');
+const { app, BrowserWindow, Menu, dialog, shell } = require('electron');
 const path = require('path');
 
 const isDev = !app.isPackaged;
@@ -14,6 +14,21 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
     },
+  });
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http')) {
+      shell.openExternal(url);
+      return { action: 'deny' };
+    }
+    return { action: 'allow' };
+  });
+
+  win.webContents.on('will-navigate', (event, url) => {
+    if (url.startsWith('http')) {
+      event.preventDefault();
+      shell.openExternal(url);
+    }
   });
 
   if (isDev) {


### PR DESCRIPTION
### Summary

This PR adds functionality to ensure any external `<a>` link (starting with `http`) opens in the user's default browser instead of within the Electron app.

### Why is this change valuable?
- Prevents users from navigating away from the main application window when clicking external links.
- Enhances user experience by preserving app context and avoiding confusion.

### Before

Previously, clicking on an external `<a>` tag would open the link within the Electron window, breaking the app flow.

https://github.com/user-attachments/assets/d48f8920-865f-4637-97e1-978ba188b80a


### After

Now, external links are intercepted and opened using the user's default system browser.

https://github.com/user-attachments/assets/052abc7d-0083-4576-bf5e-0636ada88280


### Implementation

- Modified `main.cjs` to intercept `new-window` and `will-navigate` events using `shell.openExternal`.
- Tested with test `<a>` tag added temporarily to `App.tsx`.

### How to test
1. Run the app using:
    - npm run dev
2. Add any external link in your React components temporarily.
3. Click the link — it should open in your browser.

### Related Issues

Closes #683 

